### PR TITLE
open new div within the if condition

### DIFF
--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -1,8 +1,7 @@
 {{ $plan := .Site.Data.schedule }}
 
-<div class="schedule">
 {{ if and (.Get "type") (.Get "type" | eq "table") }}
-
+<div class="schedule">
     <table>
     <thead>
         <tr>
@@ -45,9 +44,9 @@
     {{ end }}
     </tbody>
     </table>
-
+</div>
 {{ else }}
-
+<div class="schedule">
     <ul>
     {{ range $i, $week := $plan }}
         {{ $date := index $week "date" }}
@@ -77,6 +76,5 @@
         </li>
     {{ end }}
     </ul>
-
-{{ end }}
 </div>
+{{ end }}


### PR DESCRIPTION
otherwise the div would always be created, even if the condition
is not fulfilled. Depending on how the corresponding CSS class is
defined, this would lead to visible artefacts.

Therefore, the div should only be created when the condition is
also fulfilled.