### PR TITLE
Schedule: fix assignments

### DIFF
--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -20,7 +20,6 @@
       leader: "bc"
   assignment:
     - topic: "blatt01"
-      due: "21.10."
     - topic: "blatt01"
       due: "21.10."
 ---

--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -1,12 +1,12 @@
 ---
-- date: "Oct 30"
+- week: "KW40"
   lecture:
     - topic: "/orga/syllabus"
   assignment:
     - topic: "blatt01"
       due: "Oct 30"
 
-- date: "Nov 30"
+- week: "KW41"
   lecture:
     - topic: "/suche/intro"
       leader: "cagi"
@@ -18,7 +18,7 @@
     - topic: "blatt01"
       due: "Dez 30"
 
-- date: "Dez 30"
+- week: "KW42"
   lecture:
     - topic: "/mlp"
     - topic: "/csp/ac3"

--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -2,9 +2,6 @@
 - week: "KW40"
   lecture:
     - topic: "/orga/syllabus"
-  assignment:
-    - topic: "blatt01"
-      due: "Oct 30"
 
 - week: "KW41"
   lecture:
@@ -14,9 +11,7 @@
     - topic: "/suche/informiert/astar"
   assignment:
     - topic: "blatt01"
-      due: "Dez 30"
-    - topic: "blatt01"
-      due: "Dez 30"
+      due: "14.10."
 
 - week: "KW42"
   lecture:
@@ -25,7 +20,7 @@
       leader: "bc"
   assignment:
     - topic: "blatt01"
-      due: "Dez 30"
+      due: "21.10."
     - topic: "blatt01"
-      due: "Dez 30"
+      due: "21.10."
 ---

--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -3,8 +3,8 @@
   lecture:
     - topic: "/orga/syllabus"
   assignment:
-    - title: "blatt01"
-      due: "Dez 30"
+    - topic: "blatt01"
+      due: "Oct 30"
 
 - date: "Nov 30"
   lecture:
@@ -13,9 +13,9 @@
       notes: "Classes go all-virtual"
     - topic: "/suche/informiert/astar"
   assignment:
-    - title: "blatt01"
+    - topic: "blatt01"
       due: "Dez 30"
-    - title: "blatt01"
+    - topic: "blatt01"
       due: "Dez 30"
 
 - date: "Dez 30"
@@ -23,4 +23,9 @@
     - topic: "/mlp"
     - topic: "/csp/ac3"
       leader: "bc"
+  assignment:
+    - topic: "blatt01"
+      due: "Dez 30"
+    - topic: "blatt01"
+      due: "Dez 30"
 ---

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -30,7 +30,7 @@
             {{ with $.Site.GetPage $topic }}
                 <br>
                 <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
-                {{- printf " (Abgabe: %s)" $due -}}
+                {{ if $due }}{{- printf " (Abgabe: %s)" $due -}}{{ end }}
             {{ end }}
         {{ end }}
         </li>
@@ -80,7 +80,7 @@
                 {{ with $.Site.GetPage $topic }}
                 <p>
                     <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
-                    {{- printf " (Abgabe: %s)" $due -}}
+                    {{ if $due }}{{- printf " (Abgabe: %s)" $due -}}{{ end }}
                 </p>
                 {{ end }}
             {{ end }}

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -25,9 +25,9 @@
             {{ if $notes }}<br><em>Hinweis: &nbsp; {{- $notes -}}</em>{{ end }}
         {{ end }}
         {{ range $assignment }}
-            {{ $title := index . "title" }}
+            {{ $topic := index . "topic" }}
             {{ $due := index . "due" }}
-            {{ with $.Site.GetPage $title }}
+            {{ with $.Site.GetPage $topic }}
                 <br>
                 <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
                 (Abgabe: &nbsp; {{- $due -}})
@@ -75,9 +75,9 @@
             </ul>
             </td><td>
             {{ range $assignment }}
-                {{ $title := index . "title" }}
+                {{ $topic := index . "topic" }}
                 {{ $due := index . "due" }}
-                {{ with $.Site.GetPage $title }}
+                {{ with $.Site.GetPage $topic }}
                 <p>
                     <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
                     (Abgabe: &nbsp; {{- $due -}})

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -3,12 +3,12 @@
 {{ if and (.Get "type") (.Get "type" | eq "list") }}
 <div class="schedule">
     <ul>
-    {{ range $i, $week := $plan }}
-        {{ $date := index $week "date" }}
-        {{ $lecture := index $week "lecture" }}
-        {{ $assignment := index $week "assignment" }}
+    {{ range $i, $w := $plan }}
+        {{ $week := index $w "week" }}
+        {{ $lecture := index $w "lecture" }}
+        {{ $assignment := index $w "assignment" }}
         <li>
-        Woche &nbsp; {{- add $i 1 -}} &nbsp; ({{- $date -}}):
+        Woche &nbsp; {{- add $i 1 -}} &nbsp; ({{- $week -}}):
         {{ range $lecture }}
             {{ $topic := index . "topic" }}
             {{ $leader := index . "leader" }}
@@ -48,12 +48,12 @@
         </tr>
     </thead>
     <tbody>
-    {{ range $i, $week := $plan }}
-        {{ $date := index $week "date" }}
-        {{ $lecture := index $week "lecture" }}
-        {{ $assignment := index $week "assignment" }}
+    {{ range $i, $w := $plan }}
+        {{ $week := index $w "week" }}
+        {{ $lecture := index $w "lecture" }}
+        {{ $assignment := index $w "assignment" }}
         <tr>
-            <td>Woche &nbsp; {{- add $i 1 -}} &nbsp; ({{- $date -}})</td>
+            <td>Woche &nbsp; {{- add $i 1 -}} &nbsp; ({{- $week -}})</td>
             <td>
             <ul>
             {{ range $n, $l := $lecture }}

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -44,7 +44,7 @@
         <tr>
         <th>Woche</th>
         <th>Vorlesung</th>
-        <th>Aufgabenblatt</th>
+        <th>Praktikum/Übung</th>
         </tr>
     </thead>
     <tbody>

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -8,7 +8,7 @@
         {{ $lecture := index $w "lecture" }}
         {{ $assignment := index $w "assignment" }}
         <li>
-        Woche &nbsp; {{- add $i 1 -}} &nbsp; ({{- $week -}}):
+        {{- printf "Woche %d (%s):" (add $i 1) $week -}}
         {{ range $lecture }}
             {{ $topic := index . "topic" }}
             {{ $leader := index . "leader" }}
@@ -22,7 +22,7 @@
                 <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
             {{ end }}
             {{ if $leader }} ({{- $leader -}}) {{ end }}
-            {{ if $notes }}<br><em>Hinweis: &nbsp; {{- $notes -}}</em>{{ end }}
+            {{ if $notes }}<br><em>{{- printf "Hinweis: %s" $notes -}}</em>{{ end }}
         {{ end }}
         {{ range $assignment }}
             {{ $topic := index . "topic" }}
@@ -30,7 +30,7 @@
             {{ with $.Site.GetPage $topic }}
                 <br>
                 <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
-                (Abgabe: &nbsp; {{- $due -}})
+                {{- printf " (Abgabe: %s)" $due -}}
             {{ end }}
         {{ end }}
         </li>
@@ -53,7 +53,7 @@
         {{ $lecture := index $w "lecture" }}
         {{ $assignment := index $w "assignment" }}
         <tr>
-            <td>Woche &nbsp; {{- add $i 1 -}} &nbsp; ({{- $week -}})</td>
+            <td>{{- printf "Woche %d (%s)" (add $i 1) $week -}}</td>
             <td>
             <ul>
             {{ range $n, $l := $lecture }}
@@ -69,7 +69,7 @@
                     <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
                 {{ end }}
                 {{ if $leader }} ({{- $leader -}}) {{ end }}
-                {{ if $notes }}<br><em>Hinweis: &nbsp; {{- $notes -}}</em>{{ end }}
+                {{ if $notes }}<br><em>{{- printf "Hinweis: %s" $notes -}}</em>{{ end }}
                 </li>
             {{ end }}
             </ul>
@@ -80,7 +80,7 @@
                 {{ with $.Site.GetPage $topic }}
                 <p>
                     <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
-                    (Abgabe: &nbsp; {{- $due -}})
+                    {{- printf " (Abgabe: %s)" $due -}}
                 </p>
                 {{ end }}
             {{ end }}


### PR DESCRIPTION
fixes #39 

Im `data/schedule.yaml` definieren wir die Wochen (als Kalenderwoche). Zu jeder Woche wird definiert, welche Themen in der Vorlesung relevant sind und welches Aufgabenblatt im Praktikum bzw. der Übung besprochen wird. 

Entsprechend wird über den Shortcode `schedule` eine Tabelle erzeugt mit den Wochen, den Themen der jeweiligen Vorlesung und dem Aufgabenblatt im jeweiligen Praktikum/Übung. Tag und Uhrzeit von VL und Übung/Praktikum werden als bekannt vorausgesetzt (bzw. stehen im Text vor/nach dem Schedule).

Da das Aufgabenblatt eventuell nicht erst im Praktikum/in der Übung abgegeben wird, kann man hier zusätzlich noch ein Abgabedatum definieren.