### PR TITLE
Neuer Lecture-Style "lecture-cy"

### DIFF
--- a/archetypes/lecture-cy/index.md
+++ b/archetypes/lecture-cy/index.md
@@ -18,23 +18,6 @@ assignments:
 ---
 
 
-## Zusammenfassung
+## Zusammenfassung / Recap
 
 ...
-
-
-{{% outcomes %}}
-## Lernziele oder Was muss ich wissen?
-
-Platz für Lernziele
-*   Behebung von Bad Smells durch Refactoring
-
-
-{{% k1 %}}
--   Wuppie
--   Fluppie
-{{% /k1 %}}
-
-...
-
-{{% /outcomes %}}

--- a/archetypes/lecture-cy/outcomes.md
+++ b/archetypes/lecture-cy/outcomes.md
@@ -1,0 +1,24 @@
+---
+title: "Lernziele"
+disableToc: true
+hidden: true
+---
+
+
+{{% k1 %}}
+-   Wuppie
+-   Fluppie
+{{% /k1 %}}
+
+{{% k2 %}}
+-   foo
+-   bar
+{{% /k2 %}}
+
+{{% k3 %}}
+hammwanich
+{{% /k3 %}}
+
+{{% k4 %}}
+gibbetsooch
+{{% /k4 %}}

--- a/layouts/lecture-cy/single.html
+++ b/layouts/lecture-cy/single.html
@@ -5,16 +5,16 @@
     <h2>Videos</h2>
     {{ partial "youtube.html" . }}
 {{ end }}
+
 {{ .Scratch.Set "attachments_header" "Folien" }}
 {{ .Scratch.Set "attachments_level" 2 }}
 {{ partial "attachments.html" . }}
 
-
 {{ .Content }}
 
-
-{{ partial "quizzes.html" . }}
 {{ partial "assignments.html" . }}
+{{ partial "outcomes.html" . }}
+{{ partial "quizzes.html" . }}
 {{ partial "bib.html" . }}
 
 

--- a/layouts/lecture-cy/single.html
+++ b/layouts/lecture-cy/single.html
@@ -10,7 +10,9 @@
 {{ .Scratch.Set "attachments_level" 2 }}
 {{ partial "attachments.html" . }}
 
+<div class="recap">
 {{ .Content }}
+</div>
 
 {{ partial "assignments.html" . }}
 {{ partial "outcomes.html" . }}

--- a/markdown/tbd/test5/index.md
+++ b/markdown/tbd/test5/index.md
@@ -18,23 +18,6 @@ assignments:
 ---
 
 
-## Zusammenfassung
+## Zusammenfassung / Recap
 
-Hier könnte eine längere oder kürzere Zusammenfassung stehen. Sogar mit weiterer Untergliederung (H3 und tiefer) ...
-
-
-{{% outcomes %}}
-## Lernziele oder Was muss ich wissen?
-
-Platz für Lernziele
-*   Behebung von Bad Smells durch Refactoring
-
-
-{{% k1 %}}
--   Wuppie
--   Fluppie
-{{% /k1 %}}
-
-...
-
-{{% /outcomes %}}
+Hier könnte eine längere oder kürzere Zusammenfassung ("Recap") stehen. Sogar mit weiterer Untergliederung (H3 und tiefer) ...

--- a/markdown/tbd/test5/outcomes.md
+++ b/markdown/tbd/test5/outcomes.md
@@ -1,0 +1,24 @@
+---
+title: "Lernziele"
+disableToc: true
+hidden: true
+---
+
+
+{{% k1 %}}
+-   Wuppie
+-   Fluppie
+{{% /k1 %}}
+
+{{% k2 %}}
+-   foo
+-   bar
+{{% /k2 %}}
+
+{{% k3 %}}
+hammwanich
+{{% /k3 %}}
+
+{{% k4 %}}
+gibbetsooch
+{{% /k4 %}}


### PR DESCRIPTION
fixes #44 

@cyildiz Ich habe mal für #44 einen Vorschlag erarbeitet. Wenn ich Dich richtig verstanden hatte, wolltest Du in `index.md` eigentlich keine Inhalte haben, dafür dann in `recap.md` eine Zusammenfassung. Dann könnte man das Recap direkt in das `index.md` schreiben und sich die zweite Datei und auch das Partial `recap.html` sparen :) 

Alternativ kann ich aber auch die Struktur so wie geplant umbauen. Was denkst Du?