### PR TITLE
prevent pandoc to over-escape certain markdown parts

### DIFF
--- a/markdown/suche/informiert/astar/index.md
+++ b/markdown/suche/informiert/astar/index.md
@@ -1,10 +1,10 @@
 ---
 type: lecture-cg
-title: "Suche mit A*"
+title: "Suche mit `A*`{=markdown}"
 weight: 3
 ---
 
 
-## A*
+## `A*`{=markdown}
 
-...
+`...`{=markdown}

--- a/markdown/tbd/test4/index.md
+++ b/markdown/tbd/test4/index.md
@@ -24,14 +24,14 @@ fhmedia:
 *   Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
     -   Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
     -   Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
-*   sed diam nonumy eirmod tempor invidunt ut labore et dolore ...
-    a)  sed diam nonumy eirmod tempor invidunt ut labore et dolore ...
-    b)  sed diam nonumy eirmod tempor invidunt ut labore et dolore ...
+*   sed diam nonumy eirmod tempor invidunt ut labore et dolore `...`{=markdown}
+    a)  sed diam nonumy eirmod tempor invidunt ut labore et dolore `...`{=markdown}
+    b)  sed diam nonumy eirmod tempor invidunt ut labore et dolore `...`{=markdown}
 *   magna aliquyam erat, sed diam voluptua.
     1.  magna aliquyam erat, sed diam voluptua.
     2.  magna aliquyam erat, sed diam voluptua.
 
-Nummerierte Aufzählungen funktionieren scheinbar nur mit `1.`, `2.`, ...
+Nummerierte Aufzählungen funktionieren scheinbar nur mit `1.`, `2.`, `...`{=markdown}
 
 ### Hervorhebungen
 
@@ -73,7 +73,7 @@ Nummerierte Aufzählungen funktionieren scheinbar nur mit `1.`, `2.`, ...
 ```
 
 Well, inline code like `int main()` works too :)
-Also with syntax highlighting like `int main()`{.c} ...
+Also with syntax highlighting like `int main()`{.c} `...`{=markdown}
 
 
 ## Mathe und Formeln
@@ -158,12 +158,12 @@ Es gehen lt. Doku nur **Pipe-Tables**?!
 Mit dem Shortcode `expand` können Toggles realisiert werden.
 
 {{% expand %}}
-Kurzer Toggle ohne extra Namen ...
+Kurzer Toggle ohne extra Namen `...`{=markdown}
 {{% /expand %}}
 
 
 {{% expand "Was ist die Antwort?" %}}
-Toggle mit Namen ...
+Toggle mit Namen `...`{=markdown}
 
 ### Hier Überschrift im Toggle
 
@@ -182,4 +182,4 @@ Toggle mit Namen ...
 {{% /expand %}}
 
 **Anmerkung**: Laut https://gohugo.io/content-management/shortcodes/ werden Shortcodes mit `%` interpretiert und gerendert, während bei der Verwendung von `<` der eingeschlossene Code kein weiteres Rendering erfährt.
-**Achtung**: Es gibt scheinbar Shortcodes (["Videos"](#videos)), die nur mit `<` funktionieren ...
+**Achtung**: Es gibt scheinbar Shortcodes (["Videos"](#videos)), die nur mit `<` funktionieren `...`{=markdown}

--- a/markdown/tbd/testseite/index.md
+++ b/markdown/tbd/testseite/index.md
@@ -19,7 +19,7 @@ youtube:
   - id: JOmyP1ypJBs
     name: "wuppie"
   - link: https://youtu.be/ooWCzdWL2Co
-  - name: "direktlink, but not fh-media ..."
+  - name: "direktlink, but not fh-media `...`{=markdown}"
     link: https://kahoot.it/challenge/01899073?challenge-id=8471c25d-77c6-4c83-b473-6edcacfcb770_1629456236499
   - name: "this shouldn't show up as link"
 fhmedia:
@@ -27,11 +27,11 @@ fhmedia:
   - id: c5eacefca7463f3f284ce575fa3a5bafab65a3851e477bbaa9d8b9ba0cce3a1c49384f10e80e38dae73f0f3b22b342a2827850c3b8a1b85163ac5ebb616ccf67
     name: "wuppie"
   - link: https://www.fh-bielefeld.de/medienportal/m/c5eacefca7463f3f284ce575fa3a5bafab65a3851e477bbaa9d8b9ba0cce3a1c49384f10e80e38dae73f0f3b22b342a2827850c3b8a1b85163ac5ebb616ccf67
-  - name: "direktlink, but not fh-media ..."
+  - name: "direktlink, but not fh-media `...`{=markdown}"
     link: https://kahoot.it/challenge/01899073?challenge-id=8471c25d-77c6-4c83-b473-6edcacfcb770_1629456236499
   - name: "this shouldn't show up as link"
 attachments:
-  - name: "Extra Material, e.g. annotated slides ... Use This As Link Text"
+  - name: "Extra Material, e.g. annotated slides `...`{=markdown} Use This As Link Text"
     link: https://www.fh-bielefeld.de
   - link: https://www.fh-bielefeld.de
   - name: "this shouldn't show up as link"
@@ -78,14 +78,14 @@ $$
 *   Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
     -   Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
     -   Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
-*   sed diam nonumy eirmod tempor invidunt ut labore et dolore ...
-    a)  sed diam nonumy eirmod tempor invidunt ut labore et dolore ...
-    b)  sed diam nonumy eirmod tempor invidunt ut labore et dolore ...
+*   sed diam nonumy eirmod tempor invidunt ut labore et dolore `...`{=markdown}
+    a)  sed diam nonumy eirmod tempor invidunt ut labore et dolore `...`{=markdown}
+    b)  sed diam nonumy eirmod tempor invidunt ut labore et dolore `...`{=markdown}
 *   magna aliquyam erat, sed diam voluptua.
     1.  magna aliquyam erat, sed diam voluptua.
     2.  magna aliquyam erat, sed diam voluptua.
 
-Nummerierte Aufzählungen funktionieren scheinbar nur mit `1.`, `2.`, ...
+Nummerierte Aufzählungen funktionieren scheinbar nur mit `1.`, `2.`, `...`{=markdown}
 
 ### Hervorhebungen
 
@@ -159,7 +159,7 @@ Dann könnte der Abbildungsordner unterhalb von `content/mypage/` liegen und wä
 ```
 
 Well, inline code like `int main()` works too :)
-Also with syntax highlighting like `int main()`{.c} ...
+Also with syntax highlighting like `int main()`{.c} `...`{=markdown}
 
 
 ## Mathe und Formeln
@@ -295,12 +295,12 @@ Siehe [Anleitung](https://learn.netlify.app/en/shortcodes/attachments/): Wenn di
 Mit dem Shortcode `expand` können Toggles realisiert werden.
 
 {{% expand %}}
-Kurzer Toggle ohne extra Namen ...
+Kurzer Toggle ohne extra Namen `...`{=markdown}
 {{% /expand %}}
 
 
 {{% expand "Was ist die Antwort?" %}}
-Toggle mit Namen ...
+Toggle mit Namen `...`{=markdown}
 
 ### Hier Überschrift im Toggle
 
@@ -319,15 +319,15 @@ Toggle mit Namen ...
 {{% /expand %}}
 
 **Anmerkung**: Laut https://gohugo.io/content-management/shortcodes/ werden Shortcodes mit `%` interpretiert und gerendert, während bei der Verwendung von `<` der eingeschlossene Code kein weiteres Rendering erfährt.
-**Achtung**: Es gibt scheinbar Shortcodes (["Videos"](#videos)), die nur mit `<` funktionieren ...
+**Achtung**: Es gibt scheinbar Shortcodes (["Videos"](#videos)), die nur mit `<` funktionieren `...`{=markdown}
 
 
 ::: showme
-Und mit "native Divs" aus Pandoc-Markdown (muss vorverarbeitet werden) ....
+Und mit "native Divs" aus Pandoc-Markdown (muss vorverarbeitet werden) `...`{=markdown}
 
 - Stichpunkt 1
 - Stichpunkt 2
-- ...
+- `...`{=markdown}
 :::
 
 
@@ -369,7 +369,7 @@ Dann wird mit dem Shortcode `bib` (ohne Parameter) das Literaturverzeichnis gene
 Dem Shortcode `bib` (ohne Parameter) kann auch Inhalt übergeben werden (zw. öffnendem und schließendem Shortcode). Dieser wird dann als Literaturverzeichnis angezeigt (**ohne** Default-Überschrift!).
 
 {{% bib %}}
-Hier könnte ein Literaturverzeichnis entstehen ...
+Hier könnte ein Literaturverzeichnis entstehen `...`{=markdown}
 {{% /bib %}}
 
 ### Vorrang
@@ -384,7 +384,7 @@ Beim Erzeugen der Slides (Beamer/PDF) erzeugt Pandoc mit dem Bibtex-File und den
 
 Beim Erzeugen der Webseiten wird zunächst bei der Vorverarbeitung mit Pandoc plus einem Filter aus den Keys ein Link ins lokale Literaturverzeichnis erstellt und in den Text eingebettet. Danach kann beim Ausführen von Hugo der Shortcode/Partial `bib` das Literaturverzeichnis mit den entsprechenden Ankern generieren.
 
-Blablab @Russell2020 blublbubl [@Russell2020] bla [@Russell2020, S.10] ...
+Blablab @Russell2020 blublbubl [@Russell2020] bla [@Russell2020, S.10] `...`{=markdown}
 
 Hier eine Mehrfachzitierung [@Russell2014; @Russell2020; @Pedregosa2011]
 
@@ -400,7 +400,7 @@ Beim Erzeugen der Slides (Beamer/PDF) erzeugt Pandoc mit dem Bibtex-File und den
 
 Beim Erzeugen der Webseiten wird zunächst bei der Vorverarbeitung mit Pandoc plus einem Filter aus den Keys ein Link ins lokale Literaturverzeichnis erstellt und in den Text eingebettet. Danach kann beim Ausführen von Hugo der Shortcode/Partial `bib` das Literaturverzeichnis mit den entsprechenden Ankern generieren.
 
-Blablab @Russell2020 blublbubl [@Russell2020] bla [@Russell2020, S.10] ...
+Blablab @Russell2020 blublbubl [@Russell2020] bla [@Russell2020, S.10] `...`{=markdown}
 
 Hier eine Mehrfachzitierung [@Russell2014; @Russell2020; @Pedregosa2011]
 
@@ -412,7 +412,7 @@ Lorem Ipsum.
 
 In der Datei `static/css/tldr.css` finden sich die Klassen für "TLDR" etc. aus meinem [Pandoc-Lecture](https://github.com/cagix/pandoc-lecture).
 
-Ein Versuch wäre, diese Klassen explizit über ein `<div class="tldr">` etc. einzubauen. ... Wird aber von Hugo aus Sicherheitsgründen unterdrückt, im Output steht dann nur noch `<!-- raw HTML omitted -->` ... Das könnte man ggf. durch eine Konfiguration aktivieren (siehe [Stackoverflow](https://stackoverflow.com/questions/63198652/hugo-shortcode-ignored-saying-raw-html-omitted)).
+Ein Versuch wäre, diese Klassen explizit über ein `<div class="tldr">` etc. einzubauen. `...`{=markdown} Wird aber von Hugo aus Sicherheitsgründen unterdrückt, im Output steht dann nur noch `<!-- raw HTML omitted -->` `...`{=markdown} Das könnte man ggf. durch eine Konfiguration aktivieren (siehe [Stackoverflow](https://stackoverflow.com/questions/63198652/hugo-shortcode-ignored-saying-raw-html-omitted)).
 
 Ein anderer Weg könnten ["Custom Shortcode Templates"](https://gohugo.io/templates/shortcode-templates/) sein. Aber auch hier muss man letztlich das "unsafe" Rendering explizit freischalten. Offenbar wird ein Unterscheid zwischen eigenen Shortcode Templates und denen aus einem Theme gemacht (warum?!).
 
@@ -466,7 +466,7 @@ quizzes:
 Zum Einsatz als Bonusaufgabe steht der Shortcode `challenges` bereit. Der Inhalt wird als Markdown gerendert und leicht farbig vom Rest abgehoben.
 
 {{% challenges %}}
-Erstellen Sie ...
+Erstellen Sie `...`{=markdown}
 {{% /challenges %}}
 
 
@@ -523,10 +523,10 @@ Hier ein wichtiger Text!
 Oder zentriert:
 
 ::: center
-Hier wird zentriert ...
+Hier wird zentriert `...`{=markdown}
 :::
 
-Dies ist eine [wichtige]{.alert} Bemerkung. Und noch [**wichtiger**]{.alert} ... Und hier noch ein [Quellenhinweis: [URL](https://www.google.de/)]{.origin}.
+Dies ist eine [wichtige]{.alert} Bemerkung. Und noch [**wichtiger**]{.alert} `...`{=markdown} Und hier noch ein [Quellenhinweis: [URL](https://www.google.de/)]{.origin}.
 
 Für `::: columns ... :::` wurde noch kein passender Ersatz gefunden.
 


### PR DESCRIPTION
during pre-processing from markdown to markdown pandoc tends to over-escape certain
markdown elements, e.g. "..." will become "\...". this is something hugo will not
handle correctly.

so instead of writing "..." use `...`{=markdown}, instead of "A*" use `A*`{=markdown}

---

fixes #68