### PR TITLE
make: ignore error when trying to remove non-existing docker image

### DIFF
--- a/.github/actions/alpine-pandoc-hugo/Makefile
+++ b/.github/actions/alpine-pandoc-hugo/Makefile
@@ -4,4 +4,4 @@ all: Dockerfile
 
 .PHONY: clean
 clean:
-	docker rmi alpine-pandoc-hugo
+	-docker rmi alpine-pandoc-hugo


### PR DESCRIPTION
this _is_ usefull when the image already exists and shall be rebuild,
but this would lead to an error if the image does not yet exist.
so make create-docker-image just creates the image and does no