### PR TITLE
Schedule: Support für fakultative vierte Spalte

### DIFF
--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -2,6 +2,11 @@
 - week: "KW40"
   lecture:
     - topic: "/orga/syllabus"
+  misc:
+    - page: "/dtl/cal2"
+      notes: "Vortrag Thema I"
+    - notes: "Coden mit Edmonton"
+    - page: "/suche/informiert/astar"
 
 - week: "KW41"
   lecture:
@@ -22,4 +27,6 @@
     - topic: "blatt01"
     - topic: "blatt01"
       due: "21.10."
+  misc:
+    - notes: "Vortrag XYZ"
 ---

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -8,6 +8,11 @@
         <th>Woche</th>
         <th>Vorlesung</th>
         <th>Praktikum/Übung</th>
+        {{ $ifmisc := false }}
+        {{ range $i, $w := $plan }}
+            {{ with index $w "misc" }}{{ $ifmisc = true }}{{ end }}
+        {{ end }}
+        {{ with $ifmisc }}<th>Verschiedenes</th>{{ end }}
         </tr>
     </thead>
     <tbody>
@@ -15,6 +20,7 @@
         {{ $week := index $w "week" }}
         {{ $lecture := index $w "lecture" }}
         {{ $assignment := index $w "assignment" }}
+        {{ $misc := index $w "misc" }}
         <tr>
             <td>{{ printf "Woche %d (%s)" (add $i 1) $week }}</td>
             <td>
@@ -43,6 +49,18 @@
                     <a href="{{- .Permalink | safeURL -}}"><strong>{{- .Title -}}</strong></a>
                     {{ if $due }}{{ printf " (Abgabe: %s)" $due }}{{ end }}
                 </p>
+                {{ end }}
+            {{ end }}
+            </td><td>
+            {{ range $misc }}
+                {{ $page := index . "page" }}
+                {{ $notes := index . "notes" }}
+                {{ if $page }}
+                    {{ with $.Site.GetPage $page }}
+                        <p><a href="{{- .Permalink | safeURL -}}">{{- $notes | default .Title -}}</strong></a></p>
+                    {{ end }}
+                {{ else if $notes }}
+                    <p>{{- $notes -}}</p>
                 {{ end }}
             {{ end }}
             </td>

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -57,7 +57,7 @@
                 {{ $notes := index . "notes" }}
                 {{ if $page }}
                     {{ with $.Site.GetPage $page }}
-                        <p><a href="{{- .Permalink | safeURL -}}">{{- $notes | default .Title -}}</strong></a></p>
+                        <p><a href="{{- .Permalink | safeURL -}}"><strong>{{- $notes | default .Title -}}</strong></a></p>
                     {{ end }}
                 {{ else if $notes }}
                     <p>{{- $notes -}}</p>

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -9,8 +9,8 @@
         <th>Vorlesung</th>
         <th>Praktikum/Übung</th>
         {{ $ifmisc := false }}
-        {{ range $i, $w := $plan }}
-            {{ with index $w "misc" }}{{ $ifmisc = true }}{{ end }}
+        {{ range $plan }}
+            {{ with index . "misc" }}{{ $ifmisc = true }}{{ end }}
         {{ end }}
         {{ with $ifmisc }}<th>Verschiedenes</th>{{ end }}
         </tr>


### PR DESCRIPTION
Unterstützt eine weitere vierte Spalte "Verschiedenes": 

```yaml
  misc:
    - page: "/dtl/cal2"
      notes: "Vortrag Thema I"
    - notes: "Coden mit Edmonton"
    - page: "/suche/informiert/astar"
```

Wenn es im `data/schedule.yaml` keinen Eintrag mit dem Feld `misc` gibt, wird die vierte Spalte komplett ausgeblendet/nicht angezeigt.

fixes #70